### PR TITLE
Feat: Calculate Post Fee when sending out USDC

### DIFF
--- a/src/models/AssetTransfer.ts
+++ b/src/models/AssetTransfer.ts
@@ -68,4 +68,9 @@ export class AssetTransfer extends Model<AssetTransfer> {
   setCheckout!: (caller: Checkout) => void;
 
   //#endregion
+
+
+  get getFinalAmount(): number {
+    return this.amount - this.fee;
+  }
 }

--- a/src/models/Checkout.ts
+++ b/src/models/Checkout.ts
@@ -95,6 +95,11 @@ export class Checkout extends Model<Checkout> {
   fee!: number;
 
   @AllowNull(false)
+  @Default(0)
+  @Column(DataType.DECIMAL(10, 2))
+  postFee!: number;
+
+  @AllowNull(false)
   @Default("cash")
   @Column(DataType.ENUM("cash", "percent"))
   feeType!: TipType;
@@ -227,6 +232,10 @@ export class Checkout extends Model<Checkout> {
     }
 
     return amountMoney.multiply(Number(this.fee) / 100);
+  }
+
+  get postAmountFee() {
+    return this.amountMoney.multiply((this.postFee) / 100);
   }
 
   getAssetTransferMoney(amount: number) {

--- a/src/models/CheckoutRequest.ts
+++ b/src/models/CheckoutRequest.ts
@@ -152,6 +152,11 @@ export class CheckoutRequest extends Model<CheckoutRequest> {
   fee!: number;
 
   @AllowNull(false)
+  @Default(0)
+  @Column(DataType.DECIMAL(10, 2))
+  postFee!: number;
+
+  @AllowNull(false)
   @Default("percent")
   @Column(DataType.ENUM("cash", "percent"))
   feeType!: TipType;

--- a/src/routes/v2/partner.ts
+++ b/src/routes/v2/partner.ts
@@ -352,7 +352,7 @@ router.post(
         .optional()
         .isEmail()
         .run(req);
-      await check("fee", "Fee is invalid").isNumeric().run(req);
+      await check("postFee", "postFee is invalid").isNumeric().run(req);
       await check("amount", "Amount is required").notEmpty().run(req);
       await check("amount", "Amount should numeric").isNumeric().run(req);
       await check("walletAddress", "Wallet address is required")
@@ -364,18 +364,8 @@ router.post(
         return res.status(422).json({ errors: errors.array() });
       }
 
-      
-
       if (!partner.isApproved) {
         throw new Error("Your account is not approved yet. please wait.");
-      }
-      
-      const combinedFee = Number(partner.fee) + Number(data.fee);
-
-      if (combinedFee < Config.defaultFee.minFee) {
-        throw new Error(
-          `The fee should greater than or equal to ${Config.defaultFee.minFee}%`
-        );
       }
 
       const checkoutRequest = await CheckoutRequest.generateCheckoutRequest({
@@ -391,7 +381,8 @@ router.post(
         amount: data.amount,
         walletAddress: data.walletAddress,
         partnerOrderId: data.partnerOrderId,
-        fee: combinedFee,
+        fee: partner.fee,
+        postFee: data.postFee,
         feeType: partner.feeType,
         feeMethod: partner.feeMethod,
         partnerId: partner.id,

--- a/src/sequelize/migrations/20240302110220-add-postfee.js
+++ b/src/sequelize/migrations/20240302110220-add-postfee.js
@@ -1,0 +1,28 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add postFee column to checkoutRequests table
+    await queryInterface.addColumn("checkoutRequests", "postFee", {
+      type: Sequelize.DECIMAL(10, 2),
+      allowNull: false,
+      defaultValue: 0
+    });
+
+    // Add postFee column to checkouts table
+    await queryInterface.addColumn("checkouts", "postFee", {
+      type: Sequelize.DECIMAL(10, 2),
+      allowNull: false,
+      defaultValue: 0
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove postFee column from checkoutRequests table
+    await queryInterface.removeColumn('checkoutRequests', 'postFee');
+
+    // Remove postFee column from checkouts table
+    await queryInterface.removeColumn('checkouts', 'postFee');
+  }
+};


### PR DESCRIPTION
When sending out USDC we would find the service fee and mutate the values and send out the actual value to Backpack, This doesn't work well as we want to calculate the fee from the actual requested amount. This change adds a new field named postFee which takes out percentage of USDC when sending out the final value to the customer. 

**Changes**

- Add new field postFee to Checkout and CheckoutRequests Model (percentage)
- Post fee calculated value can be tracked from the assetTransfers fee column
- Post Fee calculated from the requested value * postFee
- Migrations for new columns